### PR TITLE
JIRA/IMPENDULO-226 - Story User - task list hook 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ lib/xapian_pg/_textidx
 log/
 tmp/
 
+# IntelliJ IDEA
+.idea

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,6 +21,14 @@ class TasksController < ApplicationController
     @now = true
     q = WorkUnit.where_actionable_by_user_when(@request_user, :now)
 
+    # Does a plugin want to override the default task list?
+    call_hook(:hTaskList) do |hooks|
+      result = hooks.run()
+      if result.redirectPath
+        redirect_to result.redirectPath
+      end
+    end
+
     # NOTE: This is a temporary interface which will be removed
     if params.has_key?("__worktype")
       q.where(:work_type => params["__worktype"])

--- a/app/hooks/ui_hooks.rb
+++ b/app/hooks/ui_hooks.rb
@@ -25,6 +25,10 @@ module KHooks
     h.result      :redirectPath,String,   nil,  "If set, the user will be redirected to this path instead of viewing the built-in help pages"
   end
 
+  define_hook :hTaskList do |h|
+    h.result      :redirectPath,String,   nil,  "If set, the user will be redirected to this path instead of viewing the built-in task list"
+  end
+
   define_hook :hPreSearchUI do |h|
     h.argument    :query,       String,   "Search query"
     h.argument    :subset,      KObjRef,  "Selected search subset"


### PR DESCRIPTION
added "hTaskList" hook, similar to "hHelpPage" to be used in a similar manner and redirect users to a custom task list view, in which developer can display task list in a different way alongside filters or any other feature