### PR TITLE
IMPENDULO-2166 - bugfix - issue when running LCOV coverage for files that are part of plugins with similar names

### DIFF
--- a/src/main/java/org/haplo/javascript/debugger/LCOVCoverage.java
+++ b/src/main/java/org/haplo/javascript/debugger/LCOVCoverage.java
@@ -175,7 +175,7 @@
                      Optional<Map.Entry<String, String>> pluginPathOpt = pluginToPluginLocation
                          .entrySet()
                          .stream()
-                         .filter(entry -> filename.contains(entry.getKey()))
+                         .filter(entry -> filename.contains("/" + entry.getKey() + "/"))
                          .findFirst();
                      if (!pluginPathOpt.isPresent()) {
                          return null;


### PR DESCRIPTION
# Steps to reproduce
Step 1: Create two plugins with similar names: `my_cool_plugin` and `my_cool_plugin_extra` . (`my_cool_plugin` being your main plugin that includes `my_cool_plugin_extra`)
Step 2: Populate plugins with JS files
Step 3: Produce some tests for your JS files 
Step 4: Create a haplo server for yourself and upload plugins to said server
Step 5: Run tests using `haplo-plugin -p my_cool_plugin test --coverage-format lcov --coverage-file mycoolplugin.info`
Step 6: Receive the below stack trace

# Error Stacktrace:
```
JSON::ParserError: unexpected token at '<html>
<head><title>Plugin error</title></head>
<body>
  <h1>Plugin error</h1>
  <h2>Bad argument. undefined or null passed to an API function which expected a valid object.</h2>
  <hr>
  <h3>Error location</h3>
  <pre>
  </pre>
  <h3 style="margin-top:32px">Full backtrace</h3>
  <pre>org.haplo.javascript.debugger.LCOVCoverage$Factory.getSourceLines(org/haplo/javascript/debugger/LCOVCoverage.java:292)
org.haplo.javascript.debugger.LCOVCoverage$Factory.getCoverageFrame(org/haplo/javascript/debugger/LCOVCoverage.java:185)
org.haplo.javascript.debugger.LCOVCoverage.getFrame(org/haplo/javascript/debugger/LCOVCoverage.java:90)
org.mozilla.javascript.Interpreter$CallFrame.&lt;init&gt;(org/mozilla/javascript/Interpreter.java:92)
org.mozilla.javascript.Interpreter.initFrame(org/mozilla/javascript/Interpreter.java:2946)
org.mozilla.javascript.Interpreter.interpretLoop(org/mozilla/javascript/Interpreter.java:1618)
org.mozilla.javascript.Interpreter.interpret(org/mozilla/javascript/Interpreter.java:1013)
org.mozilla.javascript.InterpretedFunction.call(org/mozilla/javascript/InterpretedFunction.java:109)
org.mozilla.javascript.optimizer.OptRuntime.call0(org/mozilla/javascript/optimizer/OptRuntime.java:36)
org.mozilla.javascript.gen.lib_javascript_lib_plugin_js_81._c_anonymous_35(org/mozilla/javascript/gen/lib/javascript/lib/plugin.js:464)
org.mozilla.javascript.gen.lib_javascript_lib_plugin_js_81.call(org/mozilla/javascript/gen/lib/javascript/lib/plugin.js)
org.mozilla.javascript.NativeArray.iterativeMethod(org/mozilla/javascript/NativeArray.java:1959)
org.mozilla.javascript.NativeArray.execIdCall(org/mozilla/javascript/NativeArray.java:370)
org.mozilla.javascript.IdFunctionObject.call(org/mozilla/javascript/IdFunctionObject.java:100)
org.mozilla.javascript.optimizer.OptRuntime.call1(org/mozilla/javascript/optimizer/OptRuntime.java:45)
org.mozilla.javascript.gen.lib_javascript_lib_plugin_js_81._c_anonymous_34(org/mozilla/javascript/gen/lib/javascript/lib/plugin.js:463)
org.mozilla.javascript.gen.lib_javascript_lib_plugin_js_81.call(org/mozilla/javascript/gen/lib/javascript/lib/plugin.js)
org.mozilla.javascript.Interpreter.interpretLoop(org/mozilla/javascript/Interpreter.java:1692)
org.mozilla.javascript.Interpreter.interpret(org/mozilla/javascript/Interpreter.java:1013)
org.mozilla.javascript.InterpretedFunction.call(org/mozilla/javascript/InterpretedFunction.java:109)
org.mozilla.javascript.ContextFactory.doTopCall(org/mozilla/javascript/ContextFactory.java:412)
org.mozilla.javascript.ScriptRuntime.doTopCall(org/mozilla/javascript/ScriptRuntime.java:3[57](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L57)8)
org.mozilla.javascript.InterpretedFunction.exec(org/mozilla/javascript/InterpretedFunction.java:121)
org.mozilla.javascript.Context.evaluateString(org/mozilla/javascript/Context.java:1234)
org.haplo.javascript.Runtime.evaluateString(org/haplo/javascript/Runtime.java:245)
java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:471)
org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:329)
opt.haplo.lib.js_support.kjavascript_plugin.invokeOther15:evaluateString(opt/haplo/lib/js_support//opt/haplo/lib/js_support/kjavascript_plugin.rb:148)
opt.haplo.lib.js_support.kjavascript_plugin.javascript_init(/opt/haplo/lib/js_support/kjavascript_plugin.rb:148)
opt.haplo.lib.js_support.js_plugin_runtime.invokeOther9:javascript_init(opt/haplo/lib/js_support//opt/haplo/lib/js_support/js_plugin_runtime.rb:136)
opt.haplo.lib.js_support.js_plugin_runtime.kapp_cache_checkout(/opt/haplo/lib/js_support/js_plugin_runtime.rb:136)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1809)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
RUBY.kapp_cache_checkout(/opt/haplo/lib/js_support/js_plugin_runtime.rb:128)
RUBY.using_runtime(/opt/haplo/lib/js_support/js_plugin_runtime.rb:59)
RUBY.while_buffering(/opt/haplo/framework/lib/notification_centre.rb:231)
RUBY.using_runtime(/opt/haplo/lib/js_support/js_plugin_runtime.rb:[58](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L58))
RUBY.kapp_cache_checkout(/opt/haplo/lib/js_support/js_plugin_runtime.rb:120)
opt.haplo.framework.lib.kapp.execution_time_ms(/opt/haplo/framework/lib/kapp.rb:2[60](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L60))
opt.haplo.framework.lib.kapp.RUBY$method$execution_time_ms$0$__VARARGS__(opt/haplo/framework/lib//opt/haplo/framework/lib/kapp.rb)
RUBY.kapp_cache_checkout(/opt/haplo/lib/js_support/js_plugin_runtime.rb:106)
RUBY.with_user(/opt/haplo/lib/auth_context.rb:[62](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L62))
RUBY.with_system_user(/opt/haplo/lib/auth_context.rb:71)
RUBY.kapp_cache_checkout(/opt/haplo/lib/js_support/js_plugin_runtime.rb:82)
opt.haplo.framework.lib.kapp_caches.invokeOther39:kapp_cache_checkout(opt/haplo/framework/lib//opt/haplo/framework/lib/kapp_caches.rb:93)
opt.haplo.framework.lib.kapp_caches.cache(/opt/haplo/framework/lib/kapp_caches.rb:93)
opt.haplo.lib.js_support.js_plugin_runtime.invokeOther0:cache(opt/haplo/lib/js_support//opt/haplo/lib/js_support/js_plugin_runtime.rb:41)
opt.haplo.lib.js_support.js_plugin_runtime.current(/opt/haplo/lib/js_support/js_plugin_runtime.rb:41)
RUBY.run_tests(/opt/haplo/lib/js_support/testing/js_plugin_test_runner.rb:77)
RUBY.run(/opt/haplo/lib/js_support/testing/js_plugin_test_runner.rb:28)
opt.haplo.framework.lib.kapp.in_application(/opt/haplo/framework/lib/kapp.rb:42)
RUBY.run(/opt/haplo/lib/js_support/testing/js_plugin_test_runner.rb:27)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:318)
java.lang.Thread.run(java/lang/Thread.java:748)
  </pre>
</body>
</html>
'
                    parse at json/ext/Parser.java:236
                    parse at /opt/jruby/jruby-9.2.11.1/lib/ruby/stdlib/json/common.rb:156
  post_with_json_response at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/lib/server.rb:129
                  command at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/lib/plugin.rb:148
                   <main> at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/lib/plugin_tool.rb:357
                     each at org/jruby/RubyArray.java:1809
                   <main> at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/lib/plugin_tool.rb:357
                  require at org/jruby/RubyKernel.java:9[74](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L74)
                  require at /opt/jruby/jruby-9.2.11.1/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:54
                   <main> at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/lib/run.rb:[75](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L75)
                     load at org/jruby/RubyKernel.java:[100](https://scm.platform.us-west-2.avalara.io/impendulo/haplo-platform/-/jobs/5615522#L100)9
                   <main> at /opt/jruby/jruby-9.2.11.1/lib/ruby/gems/shared/gems/haplo-2.5.8-java/bin/haplo-plugin:3
                     load at org/jruby/RubyKernel.java:1009
                   <main> at /opt/jruby/jruby-9.2.11.1/bin/haplo-plugin:23
```

# Explanation
Due to the previous string comparison a file that is committed to the `my_cool_plugin_extra` will resolve as being located in the `my_cool_plugin` plugin instead. Because of this when trying to load said file, it will result to a null value and throw a NullPointerException.