### PR TITLE
Added config to remove Dear toUser from CC template

### DIFF
--- a/app/plugins/std_workflow/js/std_workflow_emails.js
+++ b/app/plugins/std_workflow/js/std_workflow_emails.js
@@ -98,6 +98,8 @@ const ENTITY_SUFFIX_REPLACEMENTS = {
     "_list": "_refList"
 };
 
+const REMOVE_TO_USER_FROM_CC_TEMPLATE = !!O.application.config["std_workflow:remove_to_user_from_cc_template"];
+
 var toId = function(u) { return u.id; };
 
 // TODO I18N: Send emails needs to work in the locale of the recipient
@@ -163,7 +165,8 @@ var sendEmail = function(specification, entities, M) {
         var ccTemplate = P.template("email/cc-header");
         view.$std_workflow = {
             unsafeOriginalEmailBody: firstBody,
-            sentUser: to[0]
+            sentUser: to[0],
+            removeToUser: REMOVE_TO_USER_FROM_CC_TEMPLATE
         };
         cc.forEach(function(user) {
             view.toUser = user;

--- a/app/plugins/std_workflow/template/email/cc-header.hsvt
+++ b/app/plugins/std_workflow/template/email/cc-header.hsvt
@@ -1,5 +1,5 @@
 
-unless(toUser.isGroup) { <p> i("Dear {}") { toUser.nameFirst } </p> }
+unlessAny(toUser.isGroup $std_workflow.removeToUser) { <p> i("Dear {}") { toUser.nameFirst } </p> }
 
 <p> i("The following notification has been sent to {} and is copied below for your information.") { <b> $std_workflow.sentUser.name </b> } </p>
 


### PR DESCRIPTION
Added a config to remove '<p> i("Dear {}") { toUser.nameFirst } </p>' from the cc template. This will be the new standard for GEM.