### PR TITLE
Shared entities: use target instead of actionableBy

### DIFF
--- a/app/plugins/std_workflow/js/std_workflow_entity_shared_role.js
+++ b/app/plugins/std_workflow/js/std_workflow_entity_shared_role.js
@@ -33,7 +33,7 @@ var tableSharedRolesSelect = function(M, entityName) {
 
 var replaceActionableByMaybe = function(M, actionableBy) {
     if(USE_TARGET_FOR_ENTITIES.length) {
-        if(-1 !== USE_TARGET_FOR_ENTITIES.indexOf(actionableBy)) {
+        if(-1 !== USE_TARGET_FOR_ENTITIES.indexOf(actionableBy) && M.target) {
             let tt = M.target.split('.');
             if(tt.length === 2) {
                 return tt[1];

--- a/app/plugins/std_workflow/js/std_workflow_entity_shared_role.js
+++ b/app/plugins/std_workflow/js/std_workflow_entity_shared_role.js
@@ -11,6 +11,8 @@
 // pull tasks between theselves. Any change of user will be 'sticky' when the workflow
 // returns to that entity later on in the process.
 
+var USE_TARGET_FOR_ENTITIES = O.application.config["std_workflow:entity_shared_roles:use_target_for_entities"];
+
 var sharedEntitiesForWorkflow = {};
 
 // Database table to store the last selected entity
@@ -27,6 +29,17 @@ var tableSharedRolesSelect = function(M, entityName) {
         where("entityName","=",entityName).
         limit(1).order("id");
     return q.length ? q[0] : null;
+};
+
+var replaceActionableByMaybe = function(M, actionableBy) {
+    if(USE_TARGET_FOR_ENTITIES.length) {
+        if(-1 !== USE_TARGET_FOR_ENTITIES.indexOf(actionableBy)) {
+            let tt = M.target.split('.');
+            if(tt.length === 2) {
+                return tt[1];
+            }
+        }
+    }
 };
 
 // --------------------------------------------------------------------------
@@ -92,6 +105,9 @@ P.registerWorkflowFeature("std:entities:entity_shared_roles", function(workflow,
         if(M.workUnit.closed) { return; }
         var stateDefinition = M.$states[M.state],
             actionableBy = stateDefinition ? stateDefinition.actionableBy : undefined;
+        if(USE_TARGET_FOR_ENTITIES) {
+            actionableBy = replaceActionableByMaybe(M, actionableBy) || actionableBy;
+        }
         if(-1 === sharedEntitiesForWorkflow[workflow.fullName].indexOf(actionableBy)) { return; }
         var list = M.entities[actionableBy+"_refList"];
         if(list.length > 1) {
@@ -117,6 +133,9 @@ P.registerWorkflowFeature("std:entities:entity_shared_roles", function(workflow,
     workflow.notification({}, function(M, notify) {
         var stateDefinition = M.$states[M.state],
             actionableBy = stateDefinition ? stateDefinition.actionableBy : undefined;
+        if(USE_TARGET_FOR_ENTITIES) {
+            actionableBy = replaceActionableByMaybe(M, actionableBy) || actionableBy;
+        }
         if(-1 === sharedEntitiesForWorkflow[workflow.fullName].indexOf(actionableBy)) { return; }
         var row = tableSharedRolesSelect(M, actionableBy);
         if(row) {
@@ -152,6 +171,9 @@ P.respond("GET,POST", "/do/workflow/shared-role", [
     var stateDefinition = M.$states[M.state],
         sharedEntities = sharedEntitiesForWorkflow[workflow.fullName] || [],
         actionableBy = stateDefinition ? stateDefinition.actionableBy : undefined;
+    if(USE_TARGET_FOR_ENTITIES) {
+        actionableBy = replaceActionableByMaybe(M, actionableBy) || actionableBy;
+    }
     if(-1 === sharedEntities.indexOf(actionableBy)) { return; }
 
     var currentUserRef = O.currentUser.ref;


### PR DESCRIPTION
This change was implemented to resolve the issue surrounding delegation in the Ethics product.
In Ethics, we use "targetApproverPerson" rather than the entity name as the state's actionableBy. In this case, we want to instead check M.target for the shared entity to allow delegation.

To test, add 
`feature std:configuration-data
    property: {"std_workflow:entity_shared_roles:use_target_for_entities": ["targetApproverPerson"]}`
to ethics/hres_ethics/requirements.schema.

Upload to 9a55 (please let me know before you use the system).
Test application: https://dev9a55.infomanaged.co.uk/8v30y/ethics-application-eth2022-0165-
 - The Ethics Officers (as set on the University level) should be able to delegate and take over the task.
 - Please also check that the additional notification text is displaying correctly, e.g. 'This task was delegated to Julianna Dawidowicz by Samantha Davis.'.
